### PR TITLE
Fix Output Redirection Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .cache
 build
+.vscode
+.vs


### PR DESCRIPTION
There has been an [issue](https://github.com/xhcoding/sshpass-win32/issues/1) stating that the output redirection does not work for `sshpass`. The reason is that, when output is redirected to another device, the returned value of `GetStdHandle(STD_OUTPUT_HANDLE)` can no longer to be set with `ENABLE_VIRTUAL_TERMINAL_PROCESSING`, nor `GetConsoleScreenBufferInfo` from it. So I made this fix, to silently continue when setting `ENABLE_VIRTUAL_TERMINAL_PROCESSING` fails, and give the pseudo console a default size.

I'm new to windows API programming, so this pr is just meant to provide a tentative solution. Thank you.