### PR TITLE
feat: return child process exit code in main function

### DIFF
--- a/main.c
+++ b/main.c
@@ -48,6 +48,7 @@ static void __cdecl InputHandlerThread(LPVOID);
 
 int main(int argc, const char* argv[]) {
     Context ctx;
+    uint32_t childExitCode = 0;
 
     ParseArgs(argc, argv, &ctx);
 
@@ -87,6 +88,8 @@ int main(int argc, const char* argv[]) {
 
                 WaitForMultipleObjects(sizeof(ctx.events) / sizeof(HANDLE), ctx.events, FALSE,
                                         INFINITE);
+
+                GetExitCodeProcess(cmdProc.hProcess, &childExitCode);
             }
 
             CloseHandle(cmdProc.hThread);
@@ -107,7 +110,7 @@ int main(int argc, const char* argv[]) {
 
         CloseHandle(ctx.events[0]);
     } 
-    return S_OK == hr ? EXIT_SUCCESS : EXIT_FAILURE;
+    return S_OK == hr ? childExitCode : EXIT_FAILURE;
 }
 
 static void ParseArgs(int argc, const char* argv[], Context* ctx) {


### PR DESCRIPTION
When `ssh` or `scp` fail (return a non-zero exit code), `sshpass` still returns its own exit status instead of propagating the child process's failure.
This PR fixes that behavior by ensuring `sshpass` returns the child process's exit code.