### PR TITLE
feat: add -V/--version flag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,21 +5,38 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: setenv
-        run: echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-      - uses: jwlawson/actions-setup-cmake@v1.13
+      - uses: jwlawson/actions-setup-cmake@v2
+
+      - name: resolve version
+        id: version
+        shell: pwsh
+        run: |
+          $tag = git tag --sort=-v:refname | Select-Object -First 1
+          if (-not $tag) {
+            throw "No git tags found."
+          }
+          "git_tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       
       - name: configure
-        run: cmake -S . -B build -G"Visual Studio 17 2022"
+        run: cmake -S . -B build -G"Visual Studio 17 2022" -DSSHPASS_GIT_TAG="${{ steps.version.outputs.git_tag }}"
 
       - name: build
         run: cmake --build build --config release
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sshpass
+          path: build/Release/sshpass.exe
+          if-no-files-found: error
+
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
             files: build/Release/sshpass.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,51 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(sshpass VERSION 1.0.7)
+set(SSHPASS_VERSION_TAG "")
+
+if(DEFINED SSHPASS_GIT_TAG AND NOT SSHPASS_GIT_TAG STREQUAL "")
+  set(SSHPASS_VERSION_TAG "${SSHPASS_GIT_TAG}")
+else()
+  find_package(Git QUIET)
+  if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    execute_process(
+      COMMAND "${GIT_EXECUTABLE}" tag --sort=-v:refname
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      RESULT_VARIABLE SSHPASS_GIT_TAG_RESULT
+      OUTPUT_VARIABLE SSHPASS_GIT_TAGS
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(SSHPASS_GIT_TAG_RESULT EQUAL 0 AND NOT SSHPASS_GIT_TAGS STREQUAL "")
+      string(REPLACE "\r\n" "\n" SSHPASS_GIT_TAGS "${SSHPASS_GIT_TAGS}")
+      string(REPLACE "\r" "\n" SSHPASS_GIT_TAGS "${SSHPASS_GIT_TAGS}")
+      string(REGEX MATCH "^[^\n]+" SSHPASS_VERSION_TAG "${SSHPASS_GIT_TAGS}")
+    endif()
+  endif()
+endif()
+
+if(NOT SSHPASS_VERSION_TAG)
+  set(SSHPASS_VERSION_TAG "v0.0.0")
+endif()
+
+string(REGEX REPLACE "^refs/tags/" "" SSHPASS_VERSION_TAG "${SSHPASS_VERSION_TAG}")
+string(REGEX REPLACE "^v" "" SSHPASS_VERSION_STRING "${SSHPASS_VERSION_TAG}")
+string(REGEX MATCH "^[0-9.]+" SSHPASS_PROJECT_VERSION "${SSHPASS_VERSION_STRING}")
+
+if(NOT SSHPASS_PROJECT_VERSION)
+  message(WARNING "Could not derive a CMake project version from tag '${SSHPASS_VERSION_TAG}'. Falling back to 0.0.0.")
+  set(SSHPASS_PROJECT_VERSION "0.0.0")
+endif()
+
+project(sshpass VERSION "${SSHPASS_PROJECT_VERSION}")
+
+message(STATUS "Configuring sshpass version ${SSHPASS_VERSION_STRING} from tag '${SSHPASS_VERSION_TAG}'")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_executable(${PROJECT_NAME} main.c argparse.c)
 add_compile_options(/W4 /utf8)
-target_compile_definitions(${PROJECT_NAME} PRIVATE SSHPASS_VERSION="${PROJECT_VERSION}")
+target_compile_definitions(${PROJECT_NAME} PRIVATE SSHPASS_VERSION="${SSHPASS_VERSION_STRING}")
 set_property(TARGET ${PROJECT_NAME} PROPERTY
   MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(sshpass)
+project(sshpass VERSION 1.0.7)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_executable(${PROJECT_NAME} main.c argparse.c)
 add_compile_options(/W4 /utf8)
+target_compile_definitions(${PROJECT_NAME} PRIVATE SSHPASS_VERSION="${PROJECT_VERSION}")
 set_property(TARGET ${PROJECT_NAME} PROPERTY
   MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ winget install xhcoding.sshpass-win32
 Usage: sshpass [ options ] command arguments
 
     -h, --help    show this help message and exit
+    -V, --version Print version information
 
 Password options: With no options - password will be taken from stdin
     -f=<str>      Take password to use from file

--- a/main.c
+++ b/main.c
@@ -208,8 +208,11 @@ static void ParseArgs(int argc, const wchar_t* wargv[], char** argv, Context* ct
     int autoConfirm = 0;
     int totalArgc = argc;
 
+    int showVersion = 0;
+
     struct argparse_option options[] = {
             OPT_HELP(),
+            OPT_BOOLEAN('V', "version", &showVersion, "Print version information", NULL, 0, 0),
             OPT_GROUP("Password options: With no options - password will be taken from stdin"),
             OPT_STRING('f', NULL, &filename, "Take password to use from file", NULL, 0, 0),
             OPT_INTEGER('d', NULL, &number, "Use number as file descriptor for getting password",
@@ -230,6 +233,12 @@ static void ParseArgs(int argc, const wchar_t* wargv[], char** argv, Context* ct
     struct argparse argparse;
     argparse_init(&argparse, options, usages, ARGPARSE_STOP_AT_NON_OPTION);
     argc = argparse_parse(&argparse, argc, (const char**)argv);
+
+    if (showVersion) {
+        fprintf(stdout, "sshpass-win32 %s\n", SSHPASS_VERSION);
+        exit(EXIT_SUCCESS);
+    }
+
     if (argc == 0) {
         argparse_usage(&argparse);
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Add new flag to show basic version information:
```
    -V, --version Print version information
```

Example:
```console
> sshpass -V
sshpass-win32 1.0.7
```

Note: Don't forget to update the version in `CMakeLists.txt` for every new release